### PR TITLE
feat: wildcard origin

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -41,6 +41,9 @@
 <script src="/js/TdsServer.iife.js"></script>
 <script type="module">
   import { html, render, useState, useMemo, useEffect, useRef, useCallback } from 'https://unpkg.com/htm/preact/standalone.module.js'
+
+  const params = new URLSearchParams(location.search);
+  const allowedOrigin = params.get('allowed-origin')
   
   function App (props) {
     const [origin, setOrigin] = useState('http://localhost:3000')
@@ -59,7 +62,7 @@
     useEffect(() => {
       console.log('origin changed', origin)
 
-      var server = new TdsServer(origin, () => {return iframe.current});
+      var server = new TdsServer(allowedOrigin ?? origin, () => {return iframe.current});
       server.debug = true
       const handleSyncMsg = (msg) => {
         if (msg.payload.path) {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "docs",
     "es"
   ],
-  "peerDependencies": {
-    "eventemitter3": "^4.0.7"
-  },
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-transform-runtime": "^7.12.10",
@@ -30,7 +27,6 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.22",
-    "eventemitter3": "^4.0.7",
     "express": "^4.17.1",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
@@ -40,5 +36,8 @@
     "ts-jest": "^26.5.4",
     "tslib": "^2.1.0",
     "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "eventemitter3": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "eventemitter3": "^4.0.0"
+    "eventemitter3": "^4.0.0",
+    "memoize-one": "^6.0.0"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,10 +92,11 @@ class TdsMsgClient extends TdsMsgSubject {
 
   /**
    * 向 DC 告知自己已经准备完成
+   * @param currentOrigin 当前域名，通常情况下无需指定，仅当 server 使用通配符的时候需要 client 向其汇报准确的 origin
    */
-  setReady () {
+  setReady (currentOrigin?: string) {
     this.ready = true;
-    this.sendMessage(new TdsMsgClient.ClientReady());
+    this.sendMessage(new TdsMsgClient.ClientReady(currentOrigin));
   }
 
   /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -104,6 +104,9 @@ export class TdsMsgSyncPath extends TdsMsgBase implements TdsMsg<{ path: string 
  * 无附加参数
  */
 export class TdsMsgReady extends TdsMsgBase implements TdsMsg {
+  constructor(public origin?: string) {
+    super();
+  }
   type = TDS_MESSAGE_TYPE.TAP_MESSAGE_TYPE_READY;
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,5 @@
 import EventEmitter from 'eventemitter3';
+import memoizeOne from 'memoize-one';
 
 export interface TdsMsg<P = any> {
   type: TDS_MESSAGE_TYPE;
@@ -148,16 +149,17 @@ export class TdsMsgError<T> extends TdsMsgBase implements TdsMsg<T> {
   }
 }
 
-export function getOriginRegExp(tdsOrigin) {
+export function getOriginRegExp(tdsOrigin: string) {
   // * 转化为通配符，其余正则相关的符号全部转译
   const regexpStr = tdsOrigin.replace(/([.-\[\]()?\\^$=:])/g, '\\$1').replace(/\*/g, '.*?');
   return new RegExp(`^${regexpStr}$`);
 }
 
+const testWildcardOrigin = memoizeOne((origin: string, tdsOrigin: string) => getOriginRegExp(tdsOrigin).test(origin));
+
 export function isValidOrigin(origin: string, tdsOrigin: string) {
   if (tdsOrigin.indexOf('*') > -1) {
-    console.warn('[TdsMsg]: 警告，正在使用通配符校验域名，请勿在生产模式使用通配符校验域名。')
-    return getOriginRegExp(tdsOrigin).test(origin);
+    return testWildcardOrigin(origin, tdsOrigin);
   }
   return origin === tdsOrigin;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import {
 class TdsMsgServer extends TdsMsgSubject {
   static TdsMsgGo = TdsMsgGo;
   public ready = false;
+  private targetOrigin?: string;
 
   static ERROR_CODE = ERROR_CODE;
 
@@ -51,11 +52,16 @@ class TdsMsgServer extends TdsMsgSubject {
     super((event) => {
       if (isValidOrigin(event.origin, host)) {
         const msg = event.data;
-        this.emit(TdsMsgServer.ServerEventAll, msg)
+        this.emit(TdsMsgServer.ServerEventAll, msg);
         switch (msg.type) {
           case TDS_MESSAGE_TYPE.TAP_MESSAGE_TYPE_READY:
             console.log('[TdsMsgServer]: TapMsgClient 准备就绪');
             this.ready = true;
+            if (msg['origin']) {
+              if (isValidOrigin(msg['origin'], host)) {
+                this.targetOrigin = msg['origin'];
+              }
+            }
             this.emit(TdsMsgServer.ServerEventReady, msg);
             return;
           case TDS_MESSAGE_TYPE.TAP_MESSAGE_TYPE_MESSAGE:
@@ -108,7 +114,7 @@ class TdsMsgServer extends TdsMsgSubject {
   protected sendMessage(msg: TdsMsg) {
     const iframe = this.iframe();
     if (iframe) {
-      iframe.contentWindow?.postMessage?.(msg, this.host);
+      iframe.contentWindow?.postMessage?.(msg, this.targetOrigin ?? this.host);
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3623,6 +3623,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2271,7 +2271,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eventemitter3@^4.0.7:
+eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==


### PR DESCRIPTION
这个 PR 把 wildcard origin 提升到生产级别。

### 为什么呢

需求是这样的：有一个多租户的子服务，提供服务的域名是 `https://{tenant-slug}.example.domain`，当前的逻辑里可以使用  `https://*.example.domain` 作为 Server 的 host 参数。但实际上这样做 server 是无法给 client 发消息的，因为 postMessage 必须要传一个 [targetOrigin 参数](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#parameters) 而这个参数并不支持通配符（严格说是只支持 `*`）。

当然一种做法是不用通配符（本来也说了不建议在生产环境中使用），server 初始化的时候直接传完整的 origin。但麻烦的地方是 server 并不知道 tenant-slug 是多少，要这么做则需要先拿着（server 知道的） tenant-id 去问服务换 tenant-slug，这样就又需要涉及跨域访问等问题（现在的做法是 iframe src 填 `https://.example.domain/redirect/{tenant-id}` 直接 302 跳到 `https://{tenant-slug}.example.domain` 不涉及到跨域的访问），各方面改动也比较大。考虑到通配符是个声称支持的特性，就觉得可能的话还是把这个功能完善一下。

### 方案
既然 server 发消息需要知道精确的 client origin（server 自己又没有），那就让 client 自己报上来。最合适的时机就是 ready 消息。报上来的 origin 存在 server 的 targetOrigin 字段里在发消息的时候优先使用。
另一个小改动是因为每个消息都会需要检验一下 origin 的合法性，如果涉及到正则匹配有点浪费，所以给校验加一个内存缓存。